### PR TITLE
Add server for Railway deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log*
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "dependencies": {
     "@primer/css": "17.0.1"
   },
+  "scripts": {
+    "start": "node server.js"
+  },
   "license": "MIT"
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,36 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const HOST = '0.0.0.0';
+
+const indexPath = path.join(__dirname, 'index.html');
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/health') {
+    const payload = { status: 'ok', service: 'demo' };
+    const body = JSON.stringify(payload);
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(body)
+    });
+    res.end(body);
+    return;
+  }
+
+  fs.readFile(indexPath, (err, data) => {
+    if (err) {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('Internal Server Error');
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(data);
+  });
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`Server running at http://${HOST}:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add lightweight Node.js server to serve the demo and provide a /health endpoint
- add npm start script for Railway
- ignore node_modules and other local artifacts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692254ea39d48329810f9d17a702fad9)